### PR TITLE
Bug fix: merging strings and objects in same property threw JSON parse exception

### DIFF
--- a/mergejson.js
+++ b/mergejson.js
@@ -37,9 +37,10 @@ function merge(dominant, recessive){
         for (prop in dominant){
             if(dominant.hasOwnProperty(prop)){
                 if(
-					recessive.hasOwnProperty(prop) 
-					&& dominant[prop] instanceof Object
-					&& ! ( dominant[prop] instanceof Date )
+                    recessive.hasOwnProperty(prop)
+                    && dominant[prop] instanceof Object
+                    && ! ( dominant[prop] instanceof Date)
+	                && typeof dominant[prop] === typeof recessive[prop]
 				){
                     merged[prop] = merge(dominant[prop], recessive[prop]);
                 }else{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "mergejson",
+  "version": "1.0.31",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "combine-lists": {
+      "version": "https://github.com/jonathankeebler/combine-lists/tarball/master",
+      "integrity": "sha512-wSFF56eTrTXJ2veUgpvMUx99yxKf+OV3V65pRwIsCwQeAe8ud1ObzVbvBVvzfHydMan8F+kAanQOjs0FkwPPIw==",
+      "requires": {
+        "lodash": "^4.5.0",
+        "object-hash": "^1.1.8"
+      }
+    },
+    "deepcopy": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-0.6.3.tgz",
+      "integrity": "sha1-Y0eA8vhlardxr4+oQx7RzO5Vx7A="
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "object-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
+      "integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ=="
+    },
+    "should": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
+      "integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
+      "dev": true,
+      "requires": {
+        "should-equal": "^1.0.0",
+        "should-format": "^3.0.2",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+      "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.0.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mergejson",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Recursively merge json documents in a new one",
   "keywords": [
     "merge",

--- a/test/test.js
+++ b/test/test.js
@@ -127,3 +127,32 @@ mergejson(
 	}).should.eql({
 		date: null
 	});
+
+mergejson(
+	{
+		name: 'Anna'
+	},
+	{
+		name: {
+			first:'Anna',
+			last:'Smith'
+		}
+	}).should.eql({
+	name: 'Anna'
+});
+
+mergejson(
+	{
+		name: {
+			first:'Anna',
+			last:'Smith'
+		}
+	},
+	{
+		name: 'Anna'
+	}).should.eql({
+	name: {
+		first:'Anna',
+		last:'Smith'
+	}
+});


### PR DESCRIPTION
@khezen We found and have addressed this bug. If you approve, can we get it merged into main lib.

Sample tests that now pass:

```
mergejson(
	{
		name: 'Anna'
	},
	{
		name: {
			first:'Anna',
			last:'Smith'
		}
	}).should.eql({
	name: 'Anna'
});

mergejson(
	{
		name: {
			first:'Anna',
			last:'Smith'
		}
	},
	{
		name: 'Anna'
	}).should.eql({
	name: {
		first:'Anna',
		last:'Smith'
	}
});