### PR TITLE
 Switch to using an updated combine-lists library

### DIFF
--- a/mergejson.js
+++ b/mergejson.js
@@ -1,6 +1,6 @@
 "use strict";
 var deepcopy = require('deepcopy'),
-    combineLists = require("combine-lists");
+    combineLists = require("@compassdigital/combine-lists");
 
 function handleInput(input){
      if(typeof input !== "object" && typeof input !== "string" ){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mergejson",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@compassdigital/combine-lists": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@compassdigital/combine-lists/-/combine-lists-1.0.3.tgz",
+      "integrity": "sha512-WKpOvWRK1+cBSdgIvsLKOz7UX7Ei1+OsaKMfFQ843pN1gBQr108IaSb+LyRbhsv4hYjO89YkHriJMQLjvfxG8g==",
+      "requires": {
+        "lodash": "^4.17.10",
+        "object-hash": "^1.1.8"
+      }
+    },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
@@ -11,14 +20,6 @@
       "dev": true,
       "requires": {
         "util": "0.10.3"
-      }
-    },
-    "combine-lists": {
-      "version": "https://github.com/jonathankeebler/combine-lists/tarball/master",
-      "integrity": "sha512-wSFF56eTrTXJ2veUgpvMUx99yxKf+OV3V65pRwIsCwQeAe8ud1ObzVbvBVvzfHydMan8F+kAanQOjs0FkwPPIw==",
-      "requires": {
-        "lodash": "^4.5.0",
-        "object-hash": "^1.1.8"
       }
     },
     "deepcopy": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mergejson",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Recursively merge json documents in a new one",
   "keywords": [
     "merge",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Khezen/mergejson#readme",
   "dependencies": {
-    "combine-lists": "https://github.com/jonathankeebler/combine-lists/tarball/master",
+    "@compassdigital/combine-lists": "^1.0.3",
     "deepcopy": "^0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I can't get the maintainer of `combine-lists` to merge my changes, so I self published the library. This is just a change to that reference. /cc @khezen 

Update: it also contains a fix for a lodash vulnerability